### PR TITLE
Added support for for hexadecimal and symbol constants

### DIFF
--- a/Acl2TokenMaker.flex
+++ b/Acl2TokenMaker.flex
@@ -22,7 +22,7 @@
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307 USA.
  */
-package com.calebegg.ide;
+package org.proofpad;
 
 import java.io.*;
 import javax.swing.text.Segment;

--- a/Acl2TokenMaker.flex
+++ b/Acl2TokenMaker.flex
@@ -165,8 +165,8 @@ LetterOrUnderscore			= ({Letter}|"_")
 NonzeroDigit				= [1-9]
 Digit						= ("0"|{NonzeroDigit})
 HexDigit					= [0-9A-Fa-f]
-IdentifierStart				= ([^\t\f\r\n\ \(\)\;\|\.&\"\'])
-IdentifierPart				= ([^\t\f\r\n\ \(\)\;\|\.\"\'])
+IdentifierStart				= ([^\t\f\r\n\ \(\)\;\|\.&\"\':])
+IdentifierPart				= ([^\t\f\r\n\ \(\)\;\|\.\"\':])
 Identifier					= ({IdentifierStart}{IdentifierPart}*)|"|"[^|]"|"
 
 LineTerminator				= (\n)
@@ -182,7 +182,7 @@ RationalLiteral				= ({IntegerLiteral}"/"{Digit}+)
 HexRationalLiteral			= ({HexIntegerLiteral}"/"{HexDigit}+)
 CharacterLiteral			= "#\\"(.|"Space"|"Tab"|"Newline"|"Page"|"Rubout")
 
-Symbol						= "'"{Identifier}
+Symbol						= ("'"{Identifier}|":"{Identifier})
 
 Separator					= ([\(\)])
 

--- a/Acl2TokenMaker.flex
+++ b/Acl2TokenMaker.flex
@@ -164,6 +164,7 @@ Letter						= [A-Za-z]
 LetterOrUnderscore			= ({Letter}|"_")
 NonzeroDigit				= [1-9]
 Digit						= ("0"|{NonzeroDigit})
+HexDigit					= [0-9A-Fa-f]
 IdentifierStart				= ([^\t\f\r\n\ \(\)\;\|\.&\"\'])
 IdentifierPart				= ([^\t\f\r\n\ \(\)\;\|\.\"\'])
 Identifier					= ({IdentifierStart}{IdentifierPart}*)|"|"[^|]"|"
@@ -176,7 +177,9 @@ MLCEnd						= "|#"
 LineCommentBegin			= ";"
 
 IntegerLiteral				= (-?{Digit}+)
+HexIntegerLiteral			= (#[Xx]?-?{HexDigit}+)
 RationalLiteral				= ({IntegerLiteral}"/"{Digit}+)
+HexRationalLiteral			= ({HexIntegerLiteral}"/"{HexDigit}+)
 CharacterLiteral			= "#\\"(.|"Space"|"Tab"|"Newline"|"Page"|"Rubout")
 
 Symbol						= "'"{Identifier}
@@ -736,7 +739,9 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
 
 	/* Literals */
 	{IntegerLiteral}				{ addToken(Token.LITERAL_NUMBER_DECIMAL_INT); }
+	{HexIntegerLiteral}				{ addToken(Token.LITERAL_NUMBER_HEXADECIMAL); }
 	{RationalLiteral}				{ addToken(Token.LITERAL_NUMBER_FLOAT); }
+	{HexRationalLiteral}			{ addToken(Token.LITERAL_NUMBER_HEXADECIMAL); }
 	{CharacterLiteral}				{ addToken(Token.LITERAL_CHAR); }
 	"t" |
 	"nil" |


### PR DESCRIPTION
Hexadecimal constants (like #x12ABC) and symbol constants (like :this) and are supported.

Also, the package line was being generated as com.calebegg (which is out of date).
