### PR TITLE
Fixed some issues with placement of divisions on the proof bar

### DIFF
--- a/src/org/proofpad/SExpUtils.java
+++ b/src/org/proofpad/SExpUtils.java
@@ -50,7 +50,7 @@ public class SExpUtils {
 				}
 				if (token.isSingleChar('(')) {
 					parenLevel++;
-				} else if (token.isSingleChar(')')) {
+				} else if (token.isSingleChar(')') && parenLevel > 0) {
 					parenLevel--;
 				}
                 boolean nextTokenIsNull = token.getNextToken() == null ||

--- a/src/org/proofpad/SExpUtils.java
+++ b/src/org/proofpad/SExpUtils.java
@@ -24,6 +24,7 @@ public class SExpUtils {
 		int height = 0;
 		boolean first = false;
 		StringBuilder contents = new StringBuilder();
+		boolean contentsAdmittable = true;
 		int firstType = -1;
 		int charIndex = -1;
 		Expression prev = null;
@@ -43,6 +44,7 @@ public class SExpUtils {
 						gapHeight = height - 1;
 						height = 1;
 					}
+					contentsAdmittable = true;
 				} else if (token.isWhitespace()) {
 					contents.append(token.text, token.textOffset, token.textCount);
 				}
@@ -53,7 +55,8 @@ public class SExpUtils {
 				}
                 boolean nextTokenIsNull = token.getNextToken() == null ||
                 		token.getNextToken().type == Token.NULL;
-				if (parenLevel == 0 && nextTokenIsNull && contents.length() != 0) {
+
+				if (parenLevel == 0 && nextTokenIsNull && contents.length() != 0 && contentsAdmittable) {
 					if (prev != null) {
 						prev.nextGapHeight = gapHeight;
 					}
@@ -64,6 +67,7 @@ public class SExpUtils {
 					firstType = -1;
 					charIndex = -1;
 					contents = new StringBuilder();
+					contentsAdmittable = false;
 					height = 0;
 				}
 				if (first) first = false;


### PR DESCRIPTION
There were two issues that this fixes.

First, if you had
1
SPACE
2
, it would count as 3 expressions you could admit. (Without the space on the line between, it was 2.) Now it is 2 regardless of the space.

Second issue: If you had excess closing parentheses in one expression, it would cause divisions to be placed strangely in later expressions, because the paren depth would go negative and then make its way back to 0 partway through later expressions.
