### PR TITLE
3 little fixes

### DIFF
--- a/Acl2TokenMaker.flex
+++ b/Acl2TokenMaker.flex
@@ -192,7 +192,7 @@ Digit						= ("0"|{NonzeroDigit})
 HexDigit					= [0-9A-Fa-f]
 IdentifierStart				= ([^\t\f\r\n\ \(\)\;\|\.&\"\':,`])
 IdentifierPart				= ([^\t\f\r\n\ \(\)\;\|\.\"\':,`])
-Identifier					= ({IdentifierStart}{IdentifierPart}*)|"|"[^|]"|"
+Identifier					= ({IdentifierStart}{IdentifierPart}*)|"|"[^|]*"|"
 
 LineTerminator				= (\n)
 WhiteSpace					= ([ \t\f])

--- a/doublecheck/namespace.lisp
+++ b/doublecheck/namespace.lisp
@@ -1,40 +1,50 @@
 (in-package "ACL2")
 
-(defun namespace-replace (x prefix)
+; Prepend a prefix onto all symbols in x starting with a %. 
+(defun namespace%replace (x prefix)
    (cond ((symbolp x)
           (let ((name (symbol-name x)))
-             (cond ((zp (length name)) x)
-                   ((not (equal (char name 0) #\%)) x)
-                   ((and (<= 2 (length name))
-                         (equal (char name 1) #\%))
-                    (intern-in-package-of-symbol (subseq name 1 (- (length name) 1)) x))
-                   (t  
+             (cond ;; %SYMBOL -> PREFIX%SYMBOL
+                   ((and (<= 1 (length name))
+                         (equal (char name 0) #\%))
                     (intern-in-package-of-symbol 
-                     (concatenate 'string prefix name) x)))))
+                     (concatenate 'string prefix name) x))
+                   
+                   ;; *%SYMBOL* -> *PREFIX%SYMBOL*
+                   ((and (<= 3 (length name))
+                         (equal (char name 0) #\*)
+                         (equal (char name 1) #\%)
+                         (equal (char name (1- (length name))) #\*))
+                    (intern-in-package-of-symbol 
+                     (concatenate 'string 
+                                  "*" 
+                                  (symbol-name prefix)
+                                  (subseq name 1 (- (length name) 1))
+                                  "*") x))
+                   
+                   ;; SYMBOL -> SYMBOL
+                   (t x))))
          ((consp x)
-          (cons (namespace-replace (car x) prefix)
-                (namespace-replace (cdr x) prefix)))
+          (cons (namespace%replace (car x) prefix)
+                (namespace%replace (cdr x) prefix)))
          (t x)))
 
-(defun namespace-subst (namespace form)
-   (namespace-replace form (string-upcase (symbol-name namespace))))
-
-;(defmacro in-namespace (namespace form)
-;   (namespacify namespace form))
-
+(defun namespace%subst (namespace form)
+   (namespace%replace form (string-upcase (symbol-name namespace))))
 
 (defmacro push-namespace (namespace-name)
-   `(table namespace 'stack 
-       (cons ',namespace-name
-             (cdr (assoc-eq 'stack (table-alist 'namespace world))))))
+   (if (not (symbolp namespace-name))
+       (er hard 'pop-namespace "PUSH-NAMESPACE expects a symbol")
+   	  `(table namespace 'stack 
+               (cons ',namespace-name
+               (cdr (assoc-eq 'stack (table-alist 'namespace world)))))))
 
 (defun pop-namespace-error-message (expected-namespace actual-namespace)
    (concatenate 'string
-                "POP-namespace attempted to pop "
+                "POP-NAMESPACE attempted to pop "
                 (symbol-name expected-namespace)
                 ", but " (symbol-name actual-namespace)
                 " was on the top of the stack!"))
-
 
 (defmacro pop-namespace (namespace-name)
    `(make-event
@@ -45,22 +55,23 @@
             	 (mv nil `(table namespace 'stack ',(cdr stack)) state))
                (t (mv (pop-namespace-error-message ',namespace-name (car stack)) nil state))))))
 
-; TODO - check for empty stack
-(defmacro in-current-namespace (form)
-   `(make-event
-   	(mv-let (er stack state)
-     	   (table namespace 'stack)
-             (mv er
-                 (namespace-subst (car stack) ',form)
-                 ;(namespace-replace ,form (string-upcase (symbol-name active-namespace))))
-                 state))))
+(defmacro in-namespace (form &optional namespace)
+   (if namespace
+       (namespace%subst namespace form)
+   	`(make-event
+   		(mv-let (er stack state)
+     	   	(table namespace 'stack)
+             	(mv (or er
+                      (and (null stack)
+                          "No namespace has been entered. Use PUSH-NAMESPACE."))
+                 	(namespace%subst (car stack) ',form)
+                 	state)))))
 
 (defmacro def-namespace-form (form-name)
    (let ((form-name% (intern-in-package-of-symbol
                       (concatenate 'string (symbol-name form-name) "%") 'namespace-replace)))
    `(defmacro ,form-name% (&rest args)
-     `(in-current-namespace 
-                 (,',form-name ,@args)))))
+     `(in-namespace (,',form-name ,@args)))))
 
 (def-namespace-form defun)
 (def-namespace-form defmacro)

--- a/src/org/proofpad/BookViewer.java
+++ b/src/org/proofpad/BookViewer.java
@@ -45,6 +45,9 @@ public class BookViewer extends JFrame {
 			} else {
 				pathLen = 0;
 			}
+			if (IdeWindow.WIN) {
+				path = path.replace("\\", "/");
+			}
 			return path.substring(pathLen, path.length() - 5);
 		}
 		public boolean isBook() {


### PR DESCRIPTION
- Book paths from the BookViewer on Windows use the forward slash
- The parser |parses this kind of symbol| correctly.
- In namespace.lisp, there is some better error reporting.
