### PR TITLE
Defrandom optimized

### DIFF
--- a/doublecheck/defrandom.lisp
+++ b/doublecheck/defrandom.lisp
@@ -145,22 +145,32 @@
       nil
       (cons (random-char) (%random-char-list (1- n)))))
 
-(defrandom% %random-occurrence-count (tries occurred improb-power)
-  (if (zp tries)
-      occurred
-      (%random-occurrence-count 
-       (1- tries) 
-       (+ occurred (if (equal (%random-below-2^n improb-power 0) 0) 1 0))
-       improb-power)))
+(defconst% *%string-length-distribution*
+   '(179 879 1120 952 559 289 87 19 11 1))
+
+(make-event
+   `(defconst% *%string-length-distribution-sum*
+   		(+ ,@*defrandom%string-length-distribution* )))
+
+(defun% %pick-from-distribution (distribution n idx )
+   (if (or (endp distribution) (< idx (first distribution)))
+       n
+       (%pick-from-distribution (rest distribution)
+                                (1+ n)
+                                (- idx (first distribution)))))
+
+(defrandom% %random-string-length ()
+   (%pick-from-distribution *%string-length-distribution* 0 
+                            (%random-below *%string-length-distribution-sum*)))
 
 (defrandom% %string-of-length (n)
    (coerce (%random-char-list n) 'string))
 
 (defrandom% random-string ()
-  (%string-of-length (%random-occurrence-count 300 0 6)))
+  (%string-of-length (%random-string-length)))
 
 (defrandom% random-symbol ()
-  (intern (string-upcase (%string-of-length (%random-occurrence-count 300 1 6))) "ACL2"))
+  (intern (string-upcase (%string-of-length (1+ (%random-string-length)))) "ACL2"))
 
 (defun% %number-cases (cases n)
   (if (endp cases)

--- a/doublecheck/namespace.lisp
+++ b/doublecheck/namespace.lisp
@@ -18,7 +18,7 @@
                     (intern-in-package-of-symbol 
                      (concatenate 'string 
                                   "*" 
-                                  (symbol-name prefix)
+                                  prefix
                                   (subseq name 1 (- (length name) 1))
                                   "*") x))
                    
@@ -73,6 +73,7 @@
    `(defmacro ,form-name% (&rest args)
      `(in-namespace (,',form-name ,@args)))))
 
+(def-namespace-form defconst)
 (def-namespace-form defun)
 (def-namespace-form defmacro)
 (def-namespace-form encapsulate)


### PR DESCRIPTION
Generating random strings and symbols was slow - their lengths were being chosen from a Bernoulli distribution, and I was actually simulating a bunch of trials to build that distribution. Now I have hard-coded the particular Bernoulli distribution being used, so it generates one random integer rather than many (300).
