### PR TITLE
Fixed autoindent on Windows

### DIFF
--- a/src/org/proofpad/CodePane.java
+++ b/src/org/proofpad/CodePane.java
@@ -220,7 +220,7 @@ public class CodePane extends RSyntaxTextArea implements Iterable<Token> {
 	public void admitBelowProofLine(String form) {
 		try {
 			boolean breakBefore = pb.getReadOnlyIndex() >= 0;
-			getDocument().insertString(pb.getReadOnlyIndex() + 1, (breakBefore ? System.getProperty("line.separator") : "") + form.trim(), null);
+			getDocument().insertString(pb.getReadOnlyIndex() + 1, (breakBefore ? "\n" : "") + form.trim(), null);
 			pb.admitNextForm();
 		} catch (BadLocationException e) { }
 	}

--- a/src/org/proofpad/IdeWindow.java
+++ b/src/org/proofpad/IdeWindow.java
@@ -292,15 +292,15 @@ public class IdeWindow extends JFrame {
 					} catch (BadLocationException e) {
 						return;
 					}
-					String eol = System.getProperty("line.separator");
-					int eolLen = eol.length();
+					int eolLen = 1;
 					try {
 						String lineStr = editor.getText(offset, editor.getLineEndOffset(line) - offset);
 						Matcher whitespace = Pattern.compile("^[ \t]*").matcher(lineStr);
 						whitespace.find();
 						int whitespaceLen = whitespace.group().length();
+						
 						doc.remove(offset - eolLen, eolLen + whitespaceLen);
-						doc.insertString(offset - eolLen, eol, null);
+						doc.insertString(offset - eolLen, "\n", null);
 					} catch (BadLocationException e) { }
 				}
 			}
@@ -480,9 +480,8 @@ public class IdeWindow extends JFrame {
 			
 			@Override
 			public void readOnlyIndexChanged(int newIndex) {
-				String lineSep = System.getProperty("line.separator");
-				if (editor.getLastVisibleOffset() - lineSep.length() <= newIndex) {
-					editor.append(lineSep);
+				if (editor.getLastVisibleOffset() - 1 <= newIndex) {
+					editor.append("\n");
 				}
 				if (editor.getCaretPosition() <= newIndex + 1) {
 					editor.setCaretPosition(newIndex + 2);
@@ -902,7 +901,7 @@ public class IdeWindow extends JFrame {
 	public void includeBookAtCursor(String dirName, String path) {
 		editor.insert("(include-book \"" + path + "\""
 				       + (dirName == null ? "" : " :dir " + dirName) + ")" +
-				       System.getProperty("line.separator"),
+				       "\n",
 				       editor.getCaretPosition() - editor.getCaretOffsetFromLineStart());
 	}
 }

--- a/src/org/proofpad/SExpUtils.java
+++ b/src/org/proofpad/SExpUtils.java
@@ -6,7 +6,6 @@ import org.fife.ui.rsyntaxtextarea.Token;
 
 
 public class SExpUtils {
-	static String newline = System.getProperty("line.separator");
 	static enum ExpType {
 		NORMAL,
 		FINAL,


### PR DESCRIPTION
The platform-specific line.separator property was breaking autoindent on
Windows. The code was expecting \r\ns to separate lines, but the text area
already coerces everything to \n, so this was deleting the last character
of the previous line rather than a \r.

There is one complication, though: If you open a file that some other
editor created with \r\n line endings, they will be in the text area. So,
at least on Windows and I assume also on other platforms, we can have a
mix of \ns and \r\ns in the same file. The changed code checks for \r\n at
each specific line break removes 1 or 2 characters accordingly.

Also, I removed the inserting of platform-specific line endings by the
code pane (like when it is making everything read-only and the cursor
needs a line to sit on). This will just make a mix of \r\ns and \ns on
Windows, since we would be sticking in \r\ns while Java puts in \ns.
